### PR TITLE
🐞 fix(方法2 id重映射):

### DIFF
--- a/notebooks/第3课-初步体验问答引擎.ipynb
+++ b/notebooks/第3课-初步体验问答引擎.ipynb
@@ -93,6 +93,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "（可选）替换node.id, 有些版本的llama-index-core会将index设为随机UUID，这可能在后续使用 query_engine.query()等接口按字符串 ID 查询节点时引发 `KeyError` 错误,通过重映射可以解决这个问题"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -1076,9 +1083,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python-3.10.10",
+   "display_name": "base",
    "language": "python",
-   "name": "python-3.10.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1090,7 +1097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/第3课-初步体验问答引擎.ipynb
+++ b/notebooks/第3课-初步体验问答引擎.ipynb
@@ -93,6 +93,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 替换 UUID 为简单字符串 id，确保后续可以正确检索\n",
+    "for i, node in enumerate(nodes):\n",
+    "    node.id_ = str(i)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/第3课-初步体验问答引擎.md
+++ b/tutorials/第3课-初步体验问答引擎.md
@@ -26,6 +26,14 @@ from llama_index.core.ingestion.pipeline import run_transformations
 nodes = run_transformations(documents, transformations=transformations)
 ```
 
+（可选）替换node.id, 有些版本的llama-index-core会将index设为随机UUID，这可能在后续使用 query_engine.query()等接口按字符串 ID 查询节点时引发 `KeyError` 错误,通过重映射可以解决这个问题
+
+```
+# 替换 UUID 为简单字符串 id，确保后续可以正确检索
+for i, node in enumerate(nodes):
+    node.id_ = str(i)
+```
+
 根据节点构建索引
 ```python
 # 构建索引


### PR DESCRIPTION
重映射默认 UUID 为字符串 ID（如 '0', '1', ...），以解决使用 str ID 查询节点时报错 KeyError 的问题，可以避免通过降级 LlamaIndex 版本来规避该错误,，兼容性更好